### PR TITLE
dh-buildinfo has been removed from Debian

### DIFF
--- a/test-data/haskell-devscripts/debian/control
+++ b/test-data/haskell-devscripts/debian/control
@@ -13,7 +13,6 @@ Package: haskell-devscripts
 Architecture: all
 Depends: dctrl-tools
   , debhelper
-  , dh-buildinfo
   , ghc (>= 7.6)
   , cdbs
   , ${misc:Depends}


### PR DESCRIPTION
Hi,

This shows up in another of my cleaning efforts:

https://codesearch.debian.net/search?q=dh-buildinfo+path%3Adebian%2Fcontrol&literal=1


A bug for the other package is filed here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1118367

Here as we are talking about test data, it's not critical,
but would still be nice to get the false positive out of the CodeSearch results