### PR TITLE
Fix typos

### DIFF
--- a/Attic/DebianRelations.hs
+++ b/Attic/DebianRelations.hs
@@ -66,7 +66,7 @@ ofFormula form =
       na (Rel name (Just (SGR v)) arch) = Rel name (Just (LTE v)) arch
       na (Rel name (Just (GRE v)) arch) = Rel name (Just (SLT v)) arch
       na (Rel name (Just (LTE v)) arch) = Rel name (Just (SGR v)) arch
-      na _ = error $ "Unexepected na"
+      na _ = error $ "Unexpected na"
 
 {-
 instance Negatable Relations where

--- a/Tests.hs
+++ b/Tests.hs
@@ -796,7 +796,7 @@ main = do
             else ExitSuccess
 
 
--- Cusstom HUnit assertion, which prints the diffs without using 'show'
+-- Custom HUnit assertion, which prints the diffs without using 'show'
 assertEmptyDiff :: String -- ^ The message prefix
                 -> String -- ^ The actual diff
                 -> Assertion

--- a/changelog
+++ b/changelog
@@ -533,7 +533,7 @@ haskell-cabal-debian (4.16.1) unstable; urgency=low
 
   * Support for packaging libraries produced by the GHCJS compiler.
   * Generate debianizations that include libraries for multiple compiler
-    flavors (not yet suppored in haskell-devscripts and/or Cabal.)
+    flavors (not yet supported in haskell-devscripts and/or Cabal.)
   * Put a DEB_DEFAULT_COMPILER assignment in debian/rules if we can
     infer it from the command line options.
 
@@ -1405,7 +1405,7 @@ haskell-cabal-debian (1.6) unstable; urgency=low
 
   * Don't omit dependencies built into ghc, they should be satisfied by
     the Provides in the compiler if they are not available in the
-    repository.  However, we do need to make ghc an alterantive to any
+    repository.  However, we do need to make ghc an alternative to any
     versioned dependencies that are bundled with the compiler, since the
     built in dependencies are virtual packages and thus unversioned.
 

--- a/debian/cabal-debian.1
+++ b/debian/cabal-debian.1
@@ -147,21 +147,21 @@ Add an entry to the `Depends' field of the \fB\-dev\fR
 package
 .TP
 \fB\-\-depends\fR DEB:RELATION
-Add extry to 'Depends 'field of DEB binary package
+Add entry to 'Depends 'field of DEB binary package
 .HP
-\fB\-\-conflicts\fR DEB:RELATION Add extry to 'Conflicts 'field of DEB binary package
+\fB\-\-conflicts\fR DEB:RELATION Add entry to 'Conflicts 'field of DEB binary package
 .TP
 \fB\-\-provides\fR DEB:RELATION
-Add extry to 'Provides 'field of DEB binary package
+Add entry to 'Provides 'field of DEB binary package
 .TP
 \fB\-\-replaces\fR DEB:RELATION
-Add extry to 'Replaces 'field of DEB binary package
+Add entry to 'Replaces 'field of DEB binary package
 .TP
 \fB\-\-recommends\fR DEB:RELATION
-Add extry to 'Recommends 'field of DEB binary package
+Add entry to 'Recommends 'field of DEB binary package
 .TP
 \fB\-\-suggests\fR DEB:RELATION
-Add extry to 'Suggests 'field of DEB binary package
+Add entry to 'Suggests 'field of DEB binary package
 .TP
 \fB\-\-dep\-map\fR CABAL:DEBIANBINARYPACKAGE
 Specify what debian package name corresponds with a

--- a/debian/changelog
+++ b/debian/changelog
@@ -539,7 +539,7 @@ haskell-cabal-debian (4.16.1) unstable; urgency=low
 
   * Support for packaging libraries produced by the GHCJS compiler.
   * Generate debianizations that include libraries for multiple compiler
-    flavors (not yet suppored in haskell-devscripts and/or Cabal.)
+    flavors (not yet supported in haskell-devscripts and/or Cabal.)
   * Put a DEB_DEFAULT_COMPILER assignment in debian/rules if we can
     infer it from the command line options.
 
@@ -1411,7 +1411,7 @@ haskell-cabal-debian (1.6) unstable; urgency=low
 
   * Don't omit dependencies built into ghc, they should be satisfied by
     the Provides in the compiler if they are not available in the
-    repository.  However, we do need to make ghc an alterantive to any
+    repository.  However, we do need to make ghc an alternative to any
     versioned dependencies that are bundled with the compiler, since the
     built in dependencies are virtual packages and thus unversioned.
 

--- a/src/Debian/Debianize.hs
+++ b/src/Debian/Debianize.hs
@@ -76,7 +76,7 @@ module Debian.Debianize
     , module Debian.Debianize.CabalInfo
       -- * State monads to carry the collected information, command line options
     , module Debian.Debianize.Monad
-      -- * Functions for maping Cabal name and version number to Debian name
+      -- * Functions for mapping Cabal name and version number to Debian name
     , module Debian.Debianize.DebianName
       -- * Specific details about the particular packages and versions in the Debian repo
     , module Debian.Debianize.Details

--- a/src/Debian/Debianize/BasicInfo.hs
+++ b/src/Debian/Debianize/BasicInfo.hs
@@ -95,7 +95,7 @@ flagOptions =
       Option "" ["upgrade"] (NoArg (upgrade .= True))
              "Carefully upgrade an existing debianization",
       Option "" ["roundtrip"] (NoArg (roundtrip .= True))
-             "Rountrip a debianization to normalize it",
+             "Roundtrip a debianization to normalize it",
       Option "" ["ghc"] (NoArg (compilerFlavor .= GHC)) "Generate packages for GHC - same as --with-compiler GHC",
       Option "" ["ghcjs"] (NoArg (compilerFlavor .= GHCJS)) "Generate packages for GHCJS - same as --with-compiler GHCJS",
       Option "" ["hugs"] (NoArg (compilerFlavor .= Hugs)) "Generate packages for Hugs - same as --with-compiler GHC",

--- a/src/Debian/Debianize/Finalize.hs
+++ b/src/Debian/Debianize/Finalize.hs
@@ -104,7 +104,7 @@ finalizeDebianization goodies =
 -- debianization in other ways, so be careful not to do this twice,
 -- this function is not idempotent.  (Exported for use in unit tests.)
 -- FIXME: we should be able to run this without a PackageDescription, change
---        paramter type to Maybe PackageDescription and propagate down thru code
+--        parameter type to Maybe PackageDescription and propagate down thru code
 finalizeDebianization' ::
     (MonadIO m, MonadFail m)
     => CabalT m ()
@@ -136,7 +136,7 @@ finalizeDebianization' goodies date currentUser debhelperCompat =
        finalizeRules
        -- T.license .?= Just (Cabal.license pkgDesc)
        expandAtoms goodies
-       -- Create the binary packages for the web sites, servers, backup packges, and other executables
+       -- Create the binary packages for the web sites, servers, backup packages, and other executables
        use (A.debInfo . D.executable) >>= List.mapM_ (cabalExecBinaryPackage . fst) . Map.toList
        use (A.debInfo . D.backups) >>= List.mapM_ (cabalExecBinaryPackage . fst) . Map.toList
        use (A.debInfo . D.serverInfo) >>= List.mapM_ (cabalExecBinaryPackage . fst) . Map.toList
@@ -427,7 +427,7 @@ finalizeChangelog date currentUser =
           Just (ChangeLog (entry : maybe [] (\ (ChangeLog entries) -> entries) log))
 
 -- | Convert the extraLibs field of the cabal build info into debian
--- binary package names and make them dependendencies of the debian
+-- binary package names and make them dependencies of the debian
 -- devel package (if there is one.)
 addExtraLibDependencies :: (Monad m) => CompilerFlavor -> CabalT m ()
 addExtraLibDependencies hc =

--- a/src/Debian/Debianize/Optparse.hs
+++ b/src/Debian/Debianize/Optparse.hs
@@ -393,7 +393,7 @@ mkExtraP long@(c:cr) = many $ O.option (view _Unwrapped <$> extraRelationsR) m w
     m = O.help helpMsg
         <> O.long long
         <> O.metavar "DEB:RELATION"
-    helpMsg = "Add extry to '" ++ fieldName ++ " 'field of DEB binary package"
+    helpMsg = "Add entry to '" ++ fieldName ++ " 'field of DEB binary package"
 mkExtraP "" = error "mkExtraP: empty long option"
 
 extraDependsP :: O.Parser [ExtraDepends]

--- a/src/Debian/Debianize/Output.hs
+++ b/src/Debian/Debianize/Output.hs
@@ -93,7 +93,7 @@ performDebianizationWith goodies custom =
   parseProgramArguments >>= \CommandLineOptions {..} -> do
     -- _ <- try (readProcessWithExitCode "apt-get" ["install", "-y", "--force-yes", hcDeb (view compilerFlavor _flags)] "")
     newCabalInfo _flags >>= either
-                               (error . ("peformDebianization - " ++))
+                               (error . ("performDebianization - " ++))
                                (evalCabalT $ do
                                 handleBehaviorAdjustment _adjustment
                                 debianizeWith goodies custom

--- a/src/Debian/GHC.hs
+++ b/src/Debian/GHC.hs
@@ -156,7 +156,7 @@ compilerPackageName hc typ = do
           case (hc, typ, isDebian) of
             -- Debian puts the .haddock files in ghc-doc
             (GHC, Documentation, True) -> BinPkgName (hcname ++ "-doc")
-            -- In HVR repo the .haddock files required to buid html
+            -- In HVR repo the .haddock files required to build html
             -- are in the main compiler package.  However, the html
             -- files in ghc-<version>-htmldocs are also needed to
             -- create links.

--- a/src/Debian/Policy.hs
+++ b/src/Debian/Policy.hs
@@ -289,7 +289,7 @@ parseUploaders x =
     -- either (\ e -> error ("Failure parsing uploader list: " ++ show x ++ " -> " ++ show e)) id $ 
     where
       fixWhite c = if isSpace c then ' ' else c
-      -- We absoletely need a name.
+      -- We absolutely need a name.
       fixNameAddrs :: [NameAddr] -> Either String [NameAddr]
       fixNameAddrs xs = case mapMaybe fixNameAddr xs of
                           [] -> Left ("No valid debian maintainers in " ++ show x)

--- a/test-data/artvaluereport-data/input/debian/changelog
+++ b/test-data/artvaluereport-data/input/debian/changelog
@@ -185,7 +185,7 @@ haskell-artvaluereport-data (1.52) unstable; urgency=low
 
 haskell-artvaluereport-data (1.51) unstable; urgency=low
 
-  * Add a UUID field which will serve as a permenant identifier for the
+  * Add a UUID field which will serve as a permanent identifier for the
     report across all the servers we might create to handle these reports.
   * Add report archiving and unarchiving.
   * Add an event to replace a report by UUID number.

--- a/test-data/artvaluereport-data/output/debian/changelog
+++ b/test-data/artvaluereport-data/output/debian/changelog
@@ -172,7 +172,7 @@ haskell-artvaluereport-data (1.52) unstable; urgency=low
 
 haskell-artvaluereport-data (1.51) unstable; urgency=low
 
-  * Add a UUID field which will serve as a permenant identifier for the
+  * Add a UUID field which will serve as a permanent identifier for the
     report across all the servers we might create to handle these reports.
   * Add report archiving and unarchiving.
   * Add an event to replace a report by UUID number.


### PR DESCRIPTION
Found via `codespell -L liness,nd,lins,roundtripp,buildt,ist` and `typos --hidden --format brief`